### PR TITLE
Make instructions more portable

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,8 +5,8 @@
 Put `bcrc` somewhere such as ~/.bcrc, then start bc as follows:
 ```sh
 # you may add an alias to your bashrc file:
-#   alias bc='bc -q -l <(cat ~/.bcrc)'
-bc -l <(cat ~/.bcrc)  
+#   alias bc='~/.bcrc -l -q'
+bc ~/.bcrc -l 
 ```
 
 ## supported functions


### PR DESCRIPTION
bc -l <(cat ~/.bcrc) does not work for the dash, fish, or mksh and this change to the command makes it slightly simpler and work properly for these shells and others.